### PR TITLE
Integrate lost focus events in estimate_unit_times

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eatPrepTBA
 Title: Prepare IQB Technology Based Assessment (TBA)
-Version: 0.9.8.9010
-Date: 2026-05-29
+Version: 0.9.8.9011
+Date: 2026-06-01
 Authors@R: 
     c(person("Philipp", "Franikowski", , "philipp.franikowski@iqb.hu-berlin.de", role = c("aut"),
            comment = c(ORCID = "0000-0002-2109-7388")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# eatPrepTBA 0.9.8.9011
+
+* Added focus lost/regained event extraction to `estimate_unit_times()`, including optional block-aware handling of automatic block switches.
+* Improved unit loading summaries with failed loading counts and explicit `run_no_load` handling.
+* Added warnings when block information from `full_design` cannot be joined for automatic block-switch detection.
+* Added regression tests for focus-event durations, automatic block-switch handling, failed loading counts, and missing load starts.
+
 # eatPrepTBA 0.9.8.9010
 
 * Fixed `add_metadata()` so item and unit metadata are matched against the workspace metadata profile when Studio returns stale `isCurrent` flags. This preserves item metadata such as `Variablenbezeichnung` even when the relevant profile is marked as not current in the returned properties JSON.

--- a/R/estimate_unit_times.R
+++ b/R/estimate_unit_times.R
@@ -102,6 +102,10 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE,
     dplyr::mutate(ts = as.numeric(ts))
 
   if (!is.null(full_design)) {
+    if (!"testlet_no" %in% names(full_design)) {
+      full_design$testlet_no <- NA_integer_
+    }
+
     all_logs <- all_logs %>%
     dplyr::left_join(
       full_design %>% dplyr::select(dplyr::all_of(c(intersect(names(all_logs), names(full_design)),
@@ -109,6 +113,14 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE,
       by = intersect(names(.), intersect(names(all_logs), names(full_design))),
       multiple = "first"
     )
+
+    if (!block_self_switch && all(is.na(all_logs$testlet_no))) {
+      warning("No testlet_no values could be joined from full_design; automatic block switches cannot be identified.",
+              call. = FALSE)
+    } else if (!block_self_switch && any(is.na(all_logs$testlet_no))) {
+      warning("Some log rows have no joined testlet_no; automatic block switch detection may be incomplete.",
+              call. = FALSE)
+    }
   } else {
     print("Design tibble with block info not provided; ignoring blocks for focus event computation.
           Any unit loading start will be treated as a focus regained event where focus was lost before.")
@@ -290,7 +302,7 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE,
       )) %>%
     dplyr::mutate(
       auto_block_switch = dplyr::case_when(
-        (ts_name == "page_start_ts" & 
+        (ts_name == "page_start_ts" &
            stringr::str_detect(dplyr::lag(log_entry), "PLAYER = LOADING") &
            dplyr::lag(auto_block_switch)) ~ TRUE,
         .default = auto_block_switch

--- a/R/estimate_unit_times.R
+++ b/R/estimate_unit_times.R
@@ -2,43 +2,57 @@
 #'
 #' @param logs Tibble. Must be a logs tibble retrieved with `get_logs()` or `read_logs()`.
 #' @param use_unit_alias Boolean value. Determines whether to use unit_alias as unit identifier. If
-#'        FALSE, use unit_key instead, which is the default. 
-#'        By default, unit_alias == unit_key (mapping to the Studio unit). In special cases — 
-#'        particularly for unit start pages and units that appear identically in multiple test 
-#'        booklets but are to be evaluated separately (which is rare; this has so far only 
-#'        applied to instruction pages or clarification questions) — a different unit_alias 
+#'        FALSE, use unit_key instead, which is the default.
+#'        By default, unit_alias == unit_key (mapping to the Studio unit). In special cases —
+#'        particularly for unit start pages and units that appear identically in multiple test
+#'        booklets but are to be evaluated separately (which is rare; this has so far only
+#'        applied to instruction pages or clarification questions) — a different unit_alias
 #'        is intentionally assigned to logically identical units. In these cases, setting this
 #'        parameter to TRUE can be advisable.
+#' @param full_design Tibble. Design tibble containing block information,
+#'        and all columns to be joined with logs. Relevant for finding lost focus events.
+#' @param block_self_switch Boolean value. Were subjects able to switch to the next block themselves,
+#'        or did they have to wait for the time to run out / the test conductor to switch blocks?
+#'        This is relevant for finding lost focus events.
 #'
 #' @return Tibble containing various times and timestamps per unit and page
 #'
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
-#' Calculates estimated processing and loading times for units and pages.
+#' Calculates estimated processing and loading times for units and pages. Excludes units that never
+#' actually played.
 #' New columns and nested columns:
 #' - unit_start_time: Timestamp of first "PLAYER = RUNNING" log in this unit & booklet
 #' - unit_n_play: Number of playbacks of the unit in this session, incomplete playbacks included
-#' - unit_time: Time interval at each playback of the unit between the player's “RUNNING” state and 
-#'   the next timestamp (usually the LOADING of the next unit, re-loading of the same unit, 
+#' - n_run_no_load: Number of playbacks without previous loading log
+#' - unit_time: Time interval at each playback of the unit between the player's "RUNNING" state and
+#'   the next timestamp (usually the LOADING of the next unit, re-loading of the same unit,
 #'   sometimes the end of the booklet), summed over playbacks
-#' - unit_loadtime: Time interval between the player's “LOADING” and “RUNNING” states at each playback of the unit, 
+#' - unit_loadtime: Time interval between the player's "LOADING" and "RUNNING" states at each playback of the unit,
 #'   including the duration of unsuccessful loading attempts, summed over playbacks
 #' - unit_playbacks: Tibble containing one row with information for each playback of the unit
 #'   - unit_start_i: Running number of unit playbacks
-#'   - unit_time_i: Time interval at each playback of the unit between the player's “RUNNING” state and 
-#'   the next significant entry (usually the LOADING of the next unit, re-loading of the same unit, 
+#'   - unit_time_i: Time interval at each playback of the unit between the player's "RUNNING" state and
+#'   the next significant entry (usually the LOADING of the next unit, re-loading of the same unit,
 #'   sometimes the end of the booklet)
-#'   - unit_end_time_i: Timestamp of the next significant log entry (usually the LOADING of the next unit, re-loading of the same unit, 
+#'   - unit_end_time_i: Timestamp of the next significant log entry (usually the LOADING of the next unit, re-loading of the same unit,
 #'   sometimes the end of the booklet, i. e. the final timestamp within the current booklet playback) after start of current unit playback
 #'   - unit_start_time_i: Timestamp of start of current unit playback
-#'   - unit_loadtime_i: Time interval between the player's “LOADING” and “RUNNING” states at each playback of the unit, 
-#'   including the duration of unsuccessful loading attempts
+#'   - unit_loadtime_i: Time interval between the player's "LOADING" and "RUNNING" states at each playback of the unit,
+#'   including the duration of unsuccessful loading attempts before playback
 #'   - unit_loadstart_i: Timestamp of first "PLAYER = LOADING" for current playback of unit
 #'   - run_no_load_i: Player was logged as RUNNING, but not previously as LOADING.
 #'     In this case, load times were not calculated.
-#' - n_failed_loadings: Number of unsuccessful loading attempts for the unit
-#' - unit_page_logs: Tibble containing one row with information for each page of the unit 
+#' - n_failed_loadings: Number of failed loading attempts for the unit
+#' - focus_events: Tibble containing all focus lost and regained events within each unit, based on log entries (FOCUS HAS or HAS NOT),
+#'   as well as unit and page switches (which are considered as marking regained focus)
+#'   - focus_event_ts: Timestamp of the focus event
+#'   - focus_event_type: Type of event ("LOST" or "REGAINED", but REGAINED events are not returned)
+#'   - focus_event_unfollowed: Boolean flag for lost focus events = TRUE when NOT followed by a regained event
+#'     before another lost event appears
+#'   - focus_lost_duration: For focus lost events, time until focus regained
+#' - unit_page_logs: Tibble containing one row with information for each page of the unit.
 #'   NULL when a unit only has one page.
 #'   - page_id: Digit(s) extracted from the log entry for this page
 #'   - page_start_time: Timestamp at which page is logged in log entry
@@ -50,20 +64,21 @@
 #'     - page_start_i: Running number of playbacks of the page
 #'     - page_time_i: Time interval between CURRENT_PAGE_ID = [...] (page load completion) and
 #'       the next page load completion, the loading of a new unit, or until the end of the booklet
-#'     - page_end_time_i: Timestamp of the next page load completion, the loading of a new unit, 
+#'     - page_end_time_i: Timestamp of the next page load completion, the loading of a new unit,
 #'       or the end of the booklet (i. e. the final timestamp within the current booklet playback)
 #'     - page_start_time_i: Timestamp of CURRENT_PAGE_ID = [...] (page load completion)
 #' - unit_has_pages: Boolean, marks whether there is a unit_page_logs tibble
-#' - unit_ident: Either a copy of unit_alias or unit_key, depending on the value of 
+#' - unit_ident: Either a copy of unit_alias or unit_key, depending on the value of
 #'   use_unit_alias
-#'                  
+#'
 #' Data grouped by group, login, booklet, and a unit identifier which depends on use_unit_alias.
 #'
 #' @export
-
-estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
+#'
+estimate_unit_times <- function(logs, use_unit_alias=FALSE,
+                                full_design=NULL, block_self_switch=FALSE) {
   cli_setting()
-  
+
   if (use_unit_alias) {
     logs$unit_ident <- logs$unit_alias
   } else {
@@ -71,18 +86,36 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
   }
 
   groups_booklet <- setdiff(names(logs), c("unit_key", "unit_alias", "unit_ident", "ts", "log_entry"))
-  groups_unit <- setdiff(names(logs), c("ts", "log_entry", "unit_ident"))
-  
+  groups_unit <- setdiff(names(logs), c("ts", "log_entry", "unit_key", "unit_alias"))
+
+  logs <- logs[!duplicated(logs), ]
+
   all_logs <-
     logs %>%
     dplyr::filter(
       # Delete duplicate page identifiers as these would contaminate page time estimation
       !log_entry %>% stringr::str_detect("(CURRENT_PAGE_NR|PAGE_COUNT)"),
       # This is only a constant message stream that is not interaction-based
-      !log_entry %>% stringr::str_detect("TESTLETS_TIMELEFT")
+      !log_entry %>% stringr::str_detect("TESTLETS_TIMELEFT"),
+      !is.na(booklet_id)
     ) %>%
-    dplyr::mutate(ts = as.numeric(ts)) 
-  
+    dplyr::mutate(ts = as.numeric(ts))
+
+  if (!is.null(full_design)) {
+    all_logs <- all_logs %>%
+    dplyr::left_join(
+      full_design %>% dplyr::select(dplyr::all_of(c(intersect(names(all_logs), names(full_design)),
+                                                    "testlet_no"))),
+      by = intersect(names(.), intersect(names(all_logs), names(full_design))),
+      multiple = "first"
+    )
+  } else {
+    print("Design tibble with block info not provided; ignoring blocks for focus event computation.
+          Any unit loading start will be treated as a focus regained event where focus was lost before.")
+    block_self_switch <- TRUE
+  }
+
+
   all_logs <- all_logs %>%
     dplyr::arrange(dplyr::across(dplyr::all_of(c(groups_booklet, "ts")))) %>%
     # Unusable timestamps
@@ -97,10 +130,10 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
       ),
       is_max_ts = ts == max(ts)
     ) %>%
-    dplyr::filter((!is.na(unit_ident) & unit_ident != "") | is_max_ts) %>%
     tidyr::fill(unit_ident, .direction = "downup") %>%
+    dplyr::filter((!is.na(unit_ident) & unit_ident != "") | is_max_ts) %>%
     dplyr::ungroup()
-  
+
   all_ts <-
     all_logs %>%
     dplyr::mutate(
@@ -110,9 +143,9 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
         stringr::str_detect(log_entry, "PLAYER = LOADING") ~ "unit_load_ts",
         stringr::str_detect(log_entry, "PLAYER = RUNNING") ~ "unit_start_ts",
         stringr::str_detect(log_entry, "CURRENT_PAGE_ID") ~ "page_start_ts",
-        is_max_ts ~ "booklet_end_ts",
         log_entry == "PLAYER = PAUSED" ~ "n_paused",
-        log_entry == "FOCUS : \"HAS_NOT\"" ~ "n_lost_focus",
+        log_entry == "FOCUS : \"HAS_NOT\"" ~ "focus_lost_ts",
+        log_entry == "FOCUS : \"HAS\"" ~ "focus_regained_ts",
         .default = NA_character_
       ),
       page_id = dplyr::case_when(
@@ -128,28 +161,11 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
         .default = ts_name
       )
     )
-  
+
   all_ts <- all_ts %>%
-    # dplyr::group_by(dplyr::across(dplyr::all_of(c(groups_unit, "ts_name")))) %>%
-    # dplyr::mutate(
-    #   n_play = ifelse(ts_name == "unit_start_ts", seq_along(ts_name), NA_integer_)
-    # ) %>%
-    # dplyr::group_by(dplyr::across(dplyr::all_of(groups_unit))) %>%
-    # dplyr::arrange("ts", by_group=TRUE) %>%
-    # tidyr::fill(n_play) %>%
-    # dplyr::group_by(dplyr::across(dplyr::all_of(c(groups_unit, "n_play")))) %>% # n_play m. E. 
-    # fehlerhaft, 
-    # weil tw. PLAYER=LOADING als Ende des letzten Units gewertet wird
-    # dplyr::mutate(
-    #   n_ts = seq_along(ts_name),
-    #   ts_name = ifelse((n_ts == max(n_ts) & n_ts != 1), "unitplay_last_ts", ts_name), # Lea: 
-    #   # Nicht nutzbar für Berechnung der Spielzeiten
-    #   # einzelner Unit-Plays, weil dazwischen tw. andere Units eingespielt wurden.
-    #   # Ferner wird tw. Der Start-ts auch als End-ts (letzter ts im Play) markiert.
-    # ) %>%
     dplyr::ungroup() %>%
     dplyr::filter(!is.na(ts_name))
-  
+
   unit_logs_prep <-
     all_ts %>%
     dplyr::filter(
@@ -157,60 +173,47 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
     )  %>%
     dplyr::mutate(playercode = dplyr::case_when(log_entry == "PLAYER = LOADING" ~ 0,
                                                 log_entry == "PLAYER = RUNNING" ~ 1,
-                                                TRUE ~ 999),
+                                                .default = 999),
                   lag_unit_equal = dplyr::case_when(unit_ident == dplyr::lag(unit_ident) ~ 1,
                                                     unit_ident != dplyr::lag(unit_ident) ~ 0,
-                                                    TRUE ~ 999)) %>%
+                                                    .default = 999)) %>%
     dplyr::group_by(dplyr::across(dplyr::all_of(groups_booklet))) %>%
     dplyr::arrange("ts", by_group=TRUE)
-  
+
   # Nach wiederholten Ladeversuchen, und Unit-Starts ohne vorheriges Laden suchen
-  
-  ## Loop: too slow
-  # print("Finde wiederholte Ladeversuche, sowie Unit-Starts ohne vorheriges Laden")
-  # unit_logs_prep$duplicate_loadings <- FALSE
-  # unit_logs_prep$run_no_load <- FALSE
-  # pb = utils::txtProgressBar(min = 0, max = nrow(unit_logs_prep), initial = 2) 
-  # for (row in 2:nrow(unit_logs_prep)) {
-  #   unit_logs_prep$duplicate_loadings[[row]] <- (unit_logs_prep[row, "playercode"] == 0 &
-  #                                           unit_logs_prep[row-1, "playercode"] == 0 &
-  #                                           unit_logs_prep[row, "lag_unit_equal"] == 1)
-  #   unit_logs_prep$run_no_load[[row]] <- (unit_logs_prep[row, "playercode"] == 1 &
-  #                                           (unit_logs_prep[row-1, "playercode"] != 0 |
-  #                                              unit_logs_prep[row, "lag_unit_equal"] == 0))
-  #   utils::setTxtProgressBar(pb,row)
-  # }
-  
-  # mutate() is faster
   unit_logs_prep <- unit_logs_prep %>%
     dplyr::mutate(
-      duplicate_loadings = dplyr::case_when(playercode == 0 & dplyr::lag(playercode) == 0 &
-                                              lag_unit_equal == 1 ~ 1,
-                                            TRUE ~ 0),
+      failed_loading = dplyr::case_when(playercode == 0 & (dplyr::lead(playercode) != 1 |
+                                                              unit_ident != dplyr::lead(unit_ident)
+                                                              | is.na(dplyr::lead(playercode))) ~ TRUE,
+                                            .default = FALSE),
       run_no_load = dplyr::case_when(playercode == 1 & (dplyr::lag(playercode) != 0 |
-                                                          lag_unit_equal == 0) ~ 1,
-                                     TRUE ~ 0)
+                                                          lag_unit_equal == 0 | is.na(dplyr::lag(playercode))) ~ TRUE,
+                                     .default = FALSE),
+      duplicate_loading = dplyr::case_when(playercode == 0 & dplyr::lag(playercode) == 0 &
+                                              lag_unit_equal == 1 ~ TRUE,
+                                            .default = FALSE)
     )
-  
+
   mult_loadings <-
     unit_logs_prep %>%
     dplyr::group_by(dplyr::across(dplyr::all_of(groups_unit))) %>%
     dplyr::summarise( # Adds up all loading attempts from various unit plays
-      n_failed_loadings = sum(duplicate_loadings==1),
+      n_failed_loadings = sum(failed_loading),
       .groups = "drop"
     )
-  
+
   print("Berechne Unit-Bearbeitungs- und Ladezeiten")
   unit_logs_prep <- unit_logs_prep %>%
-    dplyr::filter(duplicate_loadings == 0) %>%
+    dplyr::filter(duplicate_loading == FALSE) %>%
     dplyr::group_by(dplyr::across(dplyr::all_of(groups_booklet))) %>%
-    dplyr::arrange("ts", by_group=TRUE) %>%  
+    dplyr::arrange("ts", by_group=TRUE) %>%
     dplyr::mutate(
       ts_next = dplyr::lead(ts),
-      unit_time = ts_next - ts, # Unit time hier definiert als Zeitspanne von Unit RUNNING 
+      unit_time = ts_next - ts, # Unit time hier definiert als Zeitspanne von Unit RUNNING
       # bis zur nächsten Aktion innerhalb des Booklets
       ts_prev = dplyr::lag(ts),
-      unit_loadtime = ts - ts_prev # Unit Loadtime hier definiert als Zeitspanne von 
+      unit_loadtime = ts - ts_prev # Unit Loadtime hier definiert als Zeitspanne von
       # PLAYER=LOADING bis zu PLAYER=RUNNING (erfolglose Ladeversuche inklusive)
     ) %>%
     dplyr::mutate(
@@ -222,11 +225,11 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
       )) %>%
     dplyr::filter(ts_name =="unit_start_ts") %>%
     dplyr::group_by(dplyr::across(dplyr::all_of(groups_unit))) %>%
-    dplyr::arrange("ts", by_group=TRUE) %>% 
+    dplyr::arrange("ts", by_group=TRUE) %>%
     dplyr::mutate(
       unit_start_i = seq_along(unit_time)
     )
-  
+
   # Multiple Unit plays
   unit_logs_starts <-
     unit_logs_prep %>%
@@ -239,15 +242,16 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
                                   "unit_loadstart_i" = "ts_prev",
                                   "run_no_load_i" = "run_no_load"))) %>%
     tidyr::nest(
-      unit_playbacks = c("unit_start_i", "unit_time_i", "unit_end_time_i", "unit_start_time_i", 
+      unit_playbacks = c("unit_start_i", "unit_time_i", "unit_end_time_i", "unit_start_time_i",
                       "unit_loadtime_i", "unit_loadstart_i", "run_no_load_i"))
-  
+
   # Bring stats together
   unit_logs <-
     unit_logs_prep %>%
     dplyr::summarise(
       unit_start_time = min(ts),
       unit_n_play = length(unit_time),
+      n_run_no_load = sum(run_no_load, na.rm = TRUE),
       unit_time = sum(unit_time, na.rm = TRUE),
       unit_loadtime =  sum(unit_loadtime, na.rm = TRUE),
       .groups = "drop"
@@ -259,8 +263,102 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
     dplyr::left_join(
       mult_loadings,
       by = dplyr::join_by(!!! groups_unit)
+    ) %>%
+    dplyr::mutate(
+      unit_loadtime = dplyr::case_when(n_run_no_load==unit_n_play ~ NA,
+                .default = unit_loadtime)
     )
-  
+
+  # Extract and combine focus lost and regained events
+  print("Berechne Focus-Events")
+
+  focus_events_combined <-
+    all_ts %>%
+    dplyr::filter(ts_name == "focus_lost_ts" | ts_name == "focus_regained_ts" |
+                    ts_name == "unit_load_ts" | ts_name == "page_start_ts" |
+                    ts_name == "booklet_end_ts") %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(c(groups_booklet)))) %>%
+    dplyr::arrange("ts", by_group=TRUE)
+
+  if (!block_self_switch) { # if blocks could not be switched actively by subjects
+  focus_events_combined <-
+    focus_events_combined %>%
+    dplyr::mutate(
+      auto_block_switch = dplyr::case_when(
+        dplyr::lag(testlet_no) != testlet_no ~ TRUE,
+        .default = FALSE
+      )) %>%
+    dplyr::mutate(
+      auto_block_switch = dplyr::case_when(
+        (ts_name == "page_start_ts" & 
+           stringr::str_detect(dplyr::lag(log_entry), "PLAYER = LOADING") &
+           dplyr::lag(auto_block_switch)) ~ TRUE,
+        .default = auto_block_switch
+      ))
+  } else { # dummy variable in case subjects could switch blocks themselves
+  focus_events_combined <-
+    focus_events_combined %>%
+    dplyr::mutate(
+      auto_block_switch = FALSE
+      )
+  }
+
+  # Process each unit's focus events
+  focus_events_nested <-
+    focus_events_combined %>%
+    dplyr::mutate(
+      event_type = dplyr::case_when(
+        ts_name == "focus_lost_ts" ~ "LOST",
+        ts_name == "focus_regained_ts" ~ "REGAINED",
+        (ts_name == "unit_load_ts" & !auto_block_switch) ~ "REGAINED",
+        (ts_name == "page_start_ts" & !auto_block_switch) ~ "REGAINED",
+        .default = NA_character_
+      ),
+      focus_event_ts = ts
+    ) %>%
+    dplyr::filter(!is.na(event_type) | ts_name == "booklet_end_ts") %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(groups_booklet))) %>%
+    dplyr::arrange("focus_event_ts", by_group=TRUE) %>%
+    dplyr::mutate(
+      focus_next_ts = dplyr::lead(focus_event_ts),
+      next_event_type = dplyr::lead(event_type),
+      prev_event_type = dplyr::lag(event_type),
+      # Flag for lost focus events not followed by regain before another loss
+      focus_event_unfollowed = dplyr::case_when(
+        event_type == "LOST" & next_event_type == "LOST" ~ TRUE,
+        .default = FALSE
+      ),
+      # Compute time during which focus was lost
+      focus_lost_duration = dplyr::case_when(
+        !focus_event_unfollowed ~ focus_next_ts - focus_event_ts,
+        .default = NA
+      ),
+      # Flag for regained focus events not preceded by loss (or preceded by another regain) LEGACY
+      focus_event_unpreceded = dplyr::case_when(
+        event_type == "REGAINED" & (is.na(prev_event_type) | prev_event_type == "REGAINED") ~ TRUE,
+        .default = FALSE
+      )
+    ) %>%
+    dplyr::filter(ts_name == "focus_lost_ts") %>%
+    dplyr::select(dplyr::all_of(c(groups_unit, "focus_event_ts", "focus_lost_duration",
+                                  "event_type", "focus_event_unfollowed"))) %>%
+    dplyr::rename(focus_event_type = "event_type") %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(groups_unit))) %>%
+    tidyr::nest(focus_events = c("focus_event_ts", "focus_event_type",
+                                 "focus_event_unfollowed", "focus_lost_duration")) %>%
+    dplyr::ungroup()
+
+  # Add combined focus events if available
+  if (nrow(focus_events_nested) > 0) {
+    unit_logs <- unit_logs %>%
+      dplyr::left_join(
+        focus_events_nested,
+        by = dplyr::join_by(!!! groups_unit)
+      )
+  } else {
+    unit_logs$focus_events <- NA
+  }
+
   # Page times
   if (any(!is.na(all_ts$page_id))) {
     print("Berechne Seiten-Bearbeitungszeiten")
@@ -268,17 +366,16 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
       all_ts %>%
       dplyr::group_by(dplyr::across(dplyr::all_of(c(groups_booklet, "unit_ident")))) %>%
       dplyr::mutate(
-        is_max_ts = ts == max(ts)
+        unit_max_ts = ts == max(ts)
       ) %>%
       dplyr::filter(
         ts_name %>% stringr::str_detect("^page_") | ts_name == "unit_load_ts" | ts_name == "booklet_end_ts"
       ) %>%
       dplyr::group_by(dplyr::across(dplyr::all_of(c(groups_booklet)))) %>%
-      dplyr::arrange("ts", by_group=TRUE) %>%  
+      dplyr::arrange("ts", by_group=TRUE) %>%
       dplyr::mutate(
         ts_next = dplyr::lead(ts),
         page_time = ts_next - ts
-        # ts = ifelse(ts_name == "page_start_ts", ts, ts_next)
       ) %>%
       dplyr::group_by(dplyr::across(dplyr::all_of(c(groups_unit)))) %>%
       dplyr::filter(
@@ -292,11 +389,11 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
       dplyr::mutate(
         page_start_i = seq_along(page_time)
       )
-    
+
     # Separate Unit start and stay times
     unit_page_logs_start <-
       unit_page_logs_prep %>%
-      dplyr::select(dplyr::all_of(c(groups_unit, 
+      dplyr::select(dplyr::all_of(c(groups_unit,
                                     "page_id",
                                     "page_start_i",
                                     "page_time_i" = "page_time",
@@ -305,7 +402,7 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
       tidyr::nest(
         page_logs_i = c("page_start_i", "page_time_i", "page_end_time_i", "page_start_time_i")
       )
-    
+
     unit_page_logs <-
       unit_page_logs_prep %>%
       dplyr::summarise(
@@ -318,11 +415,9 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
         unit_page_logs_start,
         by = dplyr::join_by(!!! c(groups_unit, "page_id"))
       ) %>%
-      tidyr::nest(unit_page_logs = dplyr::any_of(c("page_id", "page_start_time", 
+      tidyr::nest(unit_page_logs = dplyr::any_of(c("page_id", "page_start_time",
                                                    "page_n_play", "page_time", "page_logs_i")))
-    
-    # unit_page_logs$unit_page_logs[[4]]$page_logs_i
-    
+
     unit_logs <- unit_logs %>%
       dplyr::left_join(
         unit_page_logs,
@@ -331,9 +426,9 @@ estimate_unit_times <- function(logs, use_unit_alias=FALSE) {
       dplyr::mutate(
         unit_has_pages = purrr::map_lgl(unit_page_logs, function(x) !is.null(x))
       )
-    
   } else {
     print("Keine Seiten-IDs; Seiten-Bearbeitungszeiten werden nicht berechnet")
+    unit_logs$unit_page_logs <- NA
   }
   unit_logs <- unit_logs %>%
     dplyr::left_join(

--- a/man/estimate_unit_times.Rd
+++ b/man/estimate_unit_times.Rd
@@ -4,7 +4,12 @@
 \alias{estimate_unit_times}
 \title{Estimates loading and stay times for units, unit plays and pages from log data}
 \usage{
-estimate_unit_times(logs, use_unit_alias = FALSE)
+estimate_unit_times(
+  logs,
+  use_unit_alias = FALSE,
+  full_design = NULL,
+  block_self_switch = FALSE
+)
 }
 \arguments{
 \item{logs}{Tibble. Must be a logs tibble retrieved with \code{get_logs()} or \code{read_logs()}.}
@@ -17,6 +22,13 @@ booklets but are to be evaluated separately (which is rare; this has so far only
 applied to instruction pages or clarification questions) — a different unit_alias
 is intentionally assigned to logically identical units. In these cases, setting this
 parameter to TRUE can be advisable.}
+
+\item{full_design}{Tibble. Design tibble containing block information,
+and all columns to be joined with logs. Relevant for finding lost focus events.}
+
+\item{block_self_switch}{Boolean value. Were subjects able to switch to the next block themselves,
+or did they have to wait for the time to run out / the test conductor to switch blocks?
+This is relevant for finding lost focus events.}
 }
 \value{
 Tibble containing various times and timestamps per unit and page
@@ -24,33 +36,44 @@ Tibble containing various times and timestamps per unit and page
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Calculates estimated processing and loading times for units and pages.
+Calculates estimated processing and loading times for units and pages. Excludes units that never
+actually played.
 New columns and nested columns:
 \itemize{
 \item unit_start_time: Timestamp of first "PLAYER = RUNNING" log in this unit & booklet
 \item unit_n_play: Number of playbacks of the unit in this session, incomplete playbacks included
-\item unit_time: Time interval at each playback of the unit between the player's “RUNNING” state and
+\item n_run_no_load: Number of playbacks without previous loading log
+\item unit_time: Time interval at each playback of the unit between the player's "RUNNING" state and
 the next timestamp (usually the LOADING of the next unit, re-loading of the same unit,
 sometimes the end of the booklet), summed over playbacks
-\item unit_loadtime: Time interval between the player's “LOADING” and “RUNNING” states at each playback of the unit,
+\item unit_loadtime: Time interval between the player's "LOADING" and "RUNNING" states at each playback of the unit,
 including the duration of unsuccessful loading attempts, summed over playbacks
 \item unit_playbacks: Tibble containing one row with information for each playback of the unit
 \itemize{
 \item unit_start_i: Running number of unit playbacks
-\item unit_time_i: Time interval at each playback of the unit between the player's “RUNNING” state and
+\item unit_time_i: Time interval at each playback of the unit between the player's "RUNNING" state and
 the next significant entry (usually the LOADING of the next unit, re-loading of the same unit,
 sometimes the end of the booklet)
 \item unit_end_time_i: Timestamp of the next significant log entry (usually the LOADING of the next unit, re-loading of the same unit,
 sometimes the end of the booklet, i. e. the final timestamp within the current booklet playback) after start of current unit playback
 \item unit_start_time_i: Timestamp of start of current unit playback
-\item unit_loadtime_i: Time interval between the player's “LOADING” and “RUNNING” states at each playback of the unit,
-including the duration of unsuccessful loading attempts
+\item unit_loadtime_i: Time interval between the player's "LOADING" and "RUNNING" states at each playback of the unit,
+including the duration of unsuccessful loading attempts before playback
 \item unit_loadstart_i: Timestamp of first "PLAYER = LOADING" for current playback of unit
 \item run_no_load_i: Player was logged as RUNNING, but not previously as LOADING.
 In this case, load times were not calculated.
 }
-\item n_failed_loadings: Number of unsuccessful loading attempts for the unit
-\item unit_page_logs: Tibble containing one row with information for each page of the unit
+\item n_failed_loadings: Number of failed loading attempts for the unit
+\item focus_events: Tibble containing all focus lost and regained events within each unit, based on log entries (FOCUS HAS or HAS NOT),
+as well as unit and page switches (which are considered as marking regained focus)
+\itemize{
+\item focus_event_ts: Timestamp of the focus event
+\item focus_event_type: Type of event ("LOST" or "REGAINED", but REGAINED events are not returned)
+\item focus_event_unfollowed: Boolean flag for lost focus events = TRUE when NOT followed by a regained event
+before another lost event appears
+\item focus_lost_duration: For focus lost events, time until focus regained
+}
+\item unit_page_logs: Tibble containing one row with information for each page of the unit.
 NULL when a unit only has one page.
 \itemize{
 \item page_id: Digit(s) extracted from the log entry for this page

--- a/tests/testthat/test-estimate_unit_times.R
+++ b/tests/testthat/test-estimate_unit_times.R
@@ -1,0 +1,430 @@
+# Test 1
+test_that("estimate_unit_times returns tibble with expected columns", {
+  # Create minimal test data
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_1",
+    ts = c(100, 200, 300, 400, 500),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS_NOT\"",
+      "FOCUS : \"HAS\"",
+      "PLAYER = LOADING"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    testlet_no = 1
+  )
+
+  result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                full_design = design, block_self_switch = FALSE)
+
+  expect_s3_class(result, "tbl_df")
+  expect_true("unit_start_time" %in% names(result))
+  expect_true("unit_loadtime" %in% names(result))
+  expect_true("focus_events" %in% names(result))
+  expect_true("unit_page_logs" %in% names(result))
+  expect_true("unit_playbacks" %in% names(result))
+})
+
+# Test 2
+test_that("estimate_unit_times returns tibble with expected columns,
+          even without optional arguments", {
+  # Create minimal test data
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_1",
+    ts = c(100, 200, 300, 400, 500),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS_NOT\"",
+      "FOCUS : \"HAS\"",
+      "PLAYER = LOADING"
+    )
+  )
+
+  result <- estimate_unit_times(logs)
+
+  expect_s3_class(result, "tbl_df")
+  expect_true("unit_start_time" %in% names(result))
+  expect_true("unit_loadtime" %in% names(result))
+  expect_true("focus_events" %in% names(result))
+  expect_true("unit_page_logs" %in% names(result))
+  expect_true("unit_playbacks" %in% names(result))
+})
+
+# Test 3
+test_that("estimate_unit_times calculates focus lost events correctly", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = c("UNIT_1", "UNIT_1", "UNIT_1", "UNIT_1",
+                 "UNIT_2", "UNIT_2", "UNIT_2", "UNIT_2",
+                 "UNIT_3", "UNIT_3", "UNIT_3", "UNIT_3",
+                 "UNIT_4"),
+    unit_alias = NA,
+    ts = c(100, 200, 250, 350, 400, 450, 500, 550, 650, 700, 800, 850, 900),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "FOCUS : \"HAS_NOT\"",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS\"",
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS_NOT\"",
+      "FOCUS : \"HAS_NOT\"",
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "PLAYER = LOADING",
+      "FOCUS : \"HAS_NOT\"",
+      "PLAYER = LOADING"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = c("UNIT_1", "UNIT_1", "UNIT_1", "UNIT_1",
+                 "UNIT_2", "UNIT_2", "UNIT_2", "UNIT_2",
+                 "UNIT_3", "UNIT_3", "UNIT_3", "UNIT_3",
+                 "UNIT_4"),
+    testlet_no = c(1,1,1,1,1,1,1,1,2,2,2,2,2)
+  )
+
+  result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                full_design = design, block_self_switch = FALSE)
+
+  # Check that focus_events tibble is populated
+  focus_events1 <- result$focus_events[[1]]
+  expect_s3_class(focus_events1, "tbl_df")
+  expect_true("focus_event_ts" %in% names(focus_events1))
+  expect_true("focus_event_type" %in% names(focus_events1))
+  expect_true("focus_event_unfollowed" %in% names(focus_events1))
+  expect_true(focus_events1$focus_lost_duration[1] == 150)
+  focus_events2 <- result$focus_events[[2]]
+  expect_true(is.na(focus_events2$focus_lost_duration[1]))
+  expect_true(focus_events2$focus_lost_duration[2] == 250)
+  focus_events3 <- result$focus_events[[3]]
+  expect_true(focus_events3$focus_lost_duration[1] == 50)
+})
+
+# Test 4
+test_that("estimate_unit_times respects booklet endings when flagging unfollowed focus events", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_1",
+    ts = c(100, 200, 300, 400),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS_NOT\"",
+      "PLAYER = RUNNING"
+      )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    testlet_no = 1
+  )
+
+  result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                full_design = design, block_self_switch = FALSE)
+
+  focus_events <- result$focus_events[[1]]
+  expect_true(!focus_events$focus_event_unfollowed[1])
+})
+
+# Test 5
+test_that("estimate_unit_times handles multiple unit plays", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_1",
+    ts = c(100, 200, 300, 350, 450, 550),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS_NOT\"",
+      "PLAYER = LOADING"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    testlet_no = 1
+  )
+
+  result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                full_design = design, block_self_switch = FALSE)
+
+  expect_true("unit_playbacks" %in% names(result))
+  playbacks <- result$unit_playbacks[[1]]
+  expect_equal(nrow(playbacks), 2)
+})
+
+# Test 6
+test_that("estimate_unit_times creates unit_ident column correctly", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_ALIAS_1",
+    ts = c(100, 200, 300),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "PLAYER = LOADING"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_ALIAS_1",
+    testlet_no = 1
+  )
+
+  # Test with use_unit_alias = FALSE
+  result_key <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                    full_design = design, block_self_switch = FALSE)
+  expect_true(result_key$unit_key == result_key$unit_ident)
+
+  # Test with use_unit_alias = TRUE
+  result_alias <- estimate_unit_times(logs, use_unit_alias = TRUE,
+                                      full_design = design, block_self_switch = FALSE)
+  expect_true(result_alias$unit_alias == result_alias$unit_ident)
+})
+
+# Test 7
+test_that("estimate_unit_times handles missing booklet_id entries", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = c("BOOKLET_1", NA, "BOOKLET_1", "BOOKLET_1"),
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_1",
+    ts = c(100, 150, 200, 300),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "PLAYER = RUNNING",
+      "PLAYER = LOADING"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    testlet_no = 1
+  )
+
+  # Should not error and should exclude NA booklet_id entries
+  result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                full_design = design, block_self_switch = FALSE)
+  expect_true(sum(is.na(result$booklet_id)) == 0)
+})
+
+# Test 8
+test_that("estimate_unit_times returns NA focus_events when no focus events occur", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_1",
+    ts = c(100, 200, 300),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "PLAYER = LOADING"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    testlet_no = 1
+  )
+
+  result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                full_design = design, block_self_switch = FALSE)
+
+  # focus_events should be NA when no focus events are recorded
+  expect_true(is.na(result$focus_events[[1]]))
+})
+
+# Test 9
+test_that("estimate_unit_times correctly calculates loading and playback times", {
+  # Create a minimal test logs tibble with known loading and playback times
+  logs <- tibble::tibble(
+    group = c(rep("g1", 8)),
+    login = c(rep("user1", 8)),
+    booklet_id = c(rep("book1", 8)),
+    unit_key = c("u1", "u1", "u1", "u1", "u2", "u2", "u2", "u2"),
+    unit_alias = c("u1", "u1", "u1", "u1", "u2", "u2", "u2", "u2"),
+    ts = c(1000, 2000, 2500, 5000, 5100, 6000, 6500, 9000),
+    log_entry = c(
+      "PLAYER = LOADING",       # ts=1000, unit_key="u1"
+      "PLAYER = RUNNING",       # ts=2000, unit_key="u1" (loading_time = 2000-1000 = 1000)
+      "PLAYER = LOADING",       # ts=2500, unit_key="u2"
+      "SESSION END",            # ts=5000, session end (playback_time_u1 = 5000-2000 = 3000)
+      "PLAYER = LOADING",       # ts=5100, unit_key="u2"
+      "PLAYER = RUNNING",       # ts=6000, unit_key="u2" (loading_time = 6000-5100 = 900)
+      "PLAYER = LOADING",       # ts=6500, unit_key="u1"
+      "SESSION END"             # ts=9000, session end (playback_time_u2 = 9000-6000 = 3000)
+    )
+  )
+
+  result <- estimate_unit_times(logs)
+
+  # Verify that u1 has correct loading and playback times
+  u1_row <- result[result$unit_key == "u1", ]
+  expect_equal(nrow(u1_row), 1, info = "Should have one row for unit u1")
+  expect_equal(u1_row$unit_loadtime, 1000)
+  expect_equal(u1_row$unit_time, 500)
+  expect_equal(u1_row$unit_n_play, 1,
+               info = "u1 should have 1 playback")
+
+  # Verify that u2 has correct loading and playback times
+  u2_row <- result[result$unit_key == "u2", ]
+  expect_equal(nrow(u2_row), 1, info = "Should have one row for unit u2")
+  expect_equal(u2_row$unit_loadtime, 900)
+  expect_equal(u2_row$unit_time, 500)
+  expect_equal(u2_row$unit_n_play, 1,
+               info = "u2 should have 1 playback")
+})
+
+
+# Test 10
+test_that("estimate_unit_times correctly counts n_failed_loadings", {
+  # Create logs with failed loading attempts
+  logs <- tibble::tibble(
+    group = c(rep("g1", 5)),
+    login = c(rep("user1", 5)),
+    booklet_id = c(rep("book1", 5)),
+    unit_key = c("u1", "u1", "u1", "u1", "u1"),
+    unit_alias = c("u1", "u1", "u1", "u1", "u1"),
+    ts = c(1000, 1500, 2000, 3000, 4000),
+    log_entry = c(
+      "PLAYER = LOADING",       # ts=1000
+      "PLAYER = LOADING",       # ts=1500 (duplicate attempt)
+      "PLAYER = RUNNING",       # ts=2000
+      "PLAYER = LOADING",       # ts=3000
+      "PLAYER = LOADING"       # ts=4000 (duplicate attempt)
+    )
+  )
+
+  result <- estimate_unit_times(logs)
+  u1_row <- result[result$unit_key == "u1", ]
+  expect_equal(u1_row$n_failed_loadings, 3,
+               info = "Should count 3 loading attempts as failed loadings")
+
+  expect_equal(u1_row$unit_n_play, 1)
+})
+
+# Test 11
+test_that("estimate_unit_times handles multiple playbacks with different loading times", {
+  # Create logs with multiple playbacks of the same unit
+  logs <- tibble::tibble(
+    group = c(rep("g1", 10)),
+    login = c(rep("user1", 10)),
+    booklet_id = c(rep("book1", 10)),
+    unit_key = c("u1", "u1", "u1", "u1", "u1", "u1", "u1", "u1", "u1", "u1"),
+    unit_alias = c("u1", "u1", "u1", "u1", "u1", "u1", "u1", "u1", "u1", "u1"),
+    ts = c(1000, 2000, 3500, 4500, 5000, 6500, 7500, 8500, 9000, 12000),
+    log_entry = c(
+      "PLAYER = LOADING",       # ts=1000
+      "PLAYER = RUNNING",       # ts=2000
+      "PLAYER = LOADING",       # ts=3500
+      "PLAYER = RUNNING",       # ts=4500
+      "PLAYER = LOADING",       # ts=5000
+      "PLAYER = RUNNING",       # ts=6500
+      "PLAYER = LOADING",       # ts=7500
+      "PLAYER = LOADING",       # ts=8500
+      "PLAYER = RUNNING",       # ts=9000
+      "SESSION END"             # ts=12000
+    )
+  )
+
+  result <- estimate_unit_times(logs)
+  u1_row <- result[result$unit_key == "u1", ]
+
+  # Expected total loading time = 1000 + 1000 + 1500 + 1500 = 5000
+  expect_equal(u1_row$unit_loadtime, 5000,
+               info = "Total loading time should be sum of all valid loading periods")
+
+  # Expected total playback time = 1500 + 500 + 1000 + 3000 = 6000
+  expect_equal(u1_row$unit_time, 6000,
+               info = "Total playback time should be sum of all playback periods")
+
+  # Should have 4 playbacks (duplicate loading should not create extra playback)
+  expect_equal(u1_row$unit_n_play, 4,
+               info = "Should count 4 playbacks (PLAYER = RUNNING occurrences)")
+
+  # Check that unit_playbacks nested tibble has correct structure
+  expect_true(!is.null(u1_row$unit_playbacks),
+              info = "unit_playbacks should be populated")
+  expect_equal(nrow(u1_row$unit_playbacks[[1]]), 4,
+               info = "unit_playbacks should have 4 rows for 4 playbacks")
+})
+
+# Test 12
+test_that("estimate_unit_times handles run_no_load cases correctly", {
+  # Create logs where PLAYER = RUNNING occurs without prior PLAYER = LOADING
+  logs <- tibble::tibble(
+    group = c(rep("g1", 6)),
+    login = c(rep("user1", 6)),
+    booklet_id = c(rep("book1", 6)),
+    unit_key = c("u1", "u1", "u2", "u2", "u2", "u2"),
+    unit_alias = c("u1", "u1", "u2", "u2", "u2", "u2"),
+    ts = c(1000, 2000, 3000, 4000, 5000, 6000),
+    log_entry = c(
+      "PLAYER = RUNNING",       # ts=1000 (no prior LOADING for u1 at start)
+      "PLAYER = LOADING",       # ts=2000 (session end)
+      "PLAYER = LOADING",       # ts=3000
+      "PLAYER = RUNNING",       # ts=4000 (loading_time = 1000)
+      "PLAYER = LOADING",       # ts=5000 (playback_time = 1000)
+      "SESSION END"             # ts=6000 (loading_time = NA, playback_time = 1000)
+    )
+  )
+
+  result <- estimate_unit_times(logs)
+
+  u1_row <- result[result$unit_key == "u1", ]
+  u2_row <- result[result$unit_key == "u2", ]
+
+  # u1 should have run_no_load = TRUE, so loading time is NA
+  expect_equal(u1_row$unit_loadtime, NA_real_,
+               info = "u1 loading time should be NA when RUNNING occurs without prior LOADING")
+
+  # u2 should have normal loading time
+  expect_equal(u2_row$unit_loadtime, 1000,
+               info = "u2 loading time should be 1000 (4000 - 3000)")
+
+  # Check run_no_load_i in unit_playbacks
+  expect_true(u1_row$unit_playbacks[[1]]$run_no_load_i[[1]],
+              info = "u1's first playback should have run_no_load_i = TRUE")
+  expect_false(u2_row$unit_playbacks[[1]]$run_no_load_i[[1]],
+               info = "u2's first playback should have run_no_load_i = FALSE")
+})

--- a/tests/testthat/test-estimate_unit_times.R
+++ b/tests/testthat/test-estimate_unit_times.R
@@ -119,6 +119,72 @@ test_that("estimate_unit_times calculates focus lost events correctly", {
   expect_true(focus_events3$focus_lost_duration[1] == 50)
 })
 
+test_that("estimate_unit_times ignores auto block loading and first page as focus regain", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = c("UNIT_1", "UNIT_1", "UNIT_1", "UNIT_2",
+                 "UNIT_2", "UNIT_2", "UNIT_2", "UNIT_2"),
+    unit_alias = c("UNIT_1", "UNIT_1", "UNIT_1", "UNIT_2",
+                   "UNIT_2", "UNIT_2", "UNIT_2", "UNIT_2"),
+    ts = c(100, 200, 300, 400, 450, 500, 550, 600),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS_NOT\"",
+      "PLAYER = LOADING",
+      "CURRENT_PAGE_ID = 1",
+      "PLAYER = RUNNING",
+      "FOCUS : \"HAS\"",
+      "SESSION END"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = c("UNIT_1", "UNIT_2"),
+    testlet_no = c(1, 2)
+  )
+
+  result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                full_design = design, block_self_switch = FALSE)
+
+  unit_1_focus_events <- result$focus_events[[which(result$unit_key == "UNIT_1")]]
+
+  expect_equal(unit_1_focus_events$focus_lost_duration, 250)
+  expect_false(unit_1_focus_events$focus_event_unfollowed)
+})
+
+test_that("estimate_unit_times warns when block mapping cannot be joined", {
+  logs <- tibble::tibble(
+    group = "test_group",
+    login = "user1",
+    booklet_id = "BOOKLET_1",
+    unit_key = "UNIT_1",
+    unit_alias = "UNIT_1",
+    ts = c(100, 200, 300),
+    log_entry = c(
+      "PLAYER = LOADING",
+      "PLAYER = RUNNING",
+      "PLAYER = LOADING"
+    )
+  )
+
+  design <- tibble::tibble(
+    booklet_id = "BOOKLET_1",
+    unit_key = "OTHER_UNIT",
+    testlet_no = 1
+  )
+
+  expect_warning(
+    result <- estimate_unit_times(logs, use_unit_alias = FALSE,
+                                  full_design = design, block_self_switch = FALSE),
+    "testlet_no"
+  )
+  expect_s3_class(result, "tbl_df")
+})
+
 # Test 4
 test_that("estimate_unit_times respects booklet endings when flagging unfollowed focus events", {
   logs <- tibble::tibble(


### PR DESCRIPTION
Replaces #36 after the original PR was merged before the review fixes were pushed.

This branch reapplies the PR36 changes on top of the revert on main and includes the review hardening, NEWS entry, and version bump.